### PR TITLE
Add a setConfig proxy to gelf pro

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,10 @@ class GelfTransport extends Transport {
 
     callback();
   }
+
+  setConfig(opts) {
+    this.logger.setConfig(opts.gelfPro);
+  }
 }
 
 module.exports = exports = GelfTransport;


### PR DESCRIPTION
Wanted to be able to set the `fields` config in gelf-pro retroactively as documented here: https://github.com/kkamkou/node-gelf-pro#configuration